### PR TITLE
Convert seq to upper letter for searching

### DIFF
--- a/src/create_gene_dataclass.py
+++ b/src/create_gene_dataclass.py
@@ -42,7 +42,6 @@ def create_dataclass(
 
     query = f"{transcript_name}::{chrom}:{txStart}-{txEnd}"
     orf_seq = gene_seq_data.get(query)
-    orf_seq = orf_seq.upper() if orf_seq else None
     if orf_seq is None:
         raise ValueError("Query not found in gene sequence data")
 

--- a/src/generate_seq_dict_from_fasta.py
+++ b/src/generate_seq_dict_from_fasta.py
@@ -50,5 +50,5 @@ def create_sorted_seq_dict(
             copy_dict[n_que] = get_revcomp(gene_seq[n_que])
     result = {}
     for n_que, s_que in zip(normal_query, sorted_query):
-        result[s_que] = copy_dict[n_que]
+        result[s_que] = copy_dict[n_que].upper()
     return result


### PR DESCRIPTION
gRNAの検索の際に低複雑度領域が小文字のためマッチしない問題を解決するために、配列をdataclassに保存するときに大文字とするようにしました。