### PR TITLE
Fix search guiode

### DIFF
--- a/src/konezumiaid/nominate_candidate_stopcodon/make_grna_from_index.py
+++ b/src/konezumiaid/nominate_candidate_stopcodon/make_grna_from_index.py
@@ -22,7 +22,7 @@ def convert_ct_grna(ds: GeneData, indices: list[int]) -> list[str]:
                 sgRNA = ds.orf_seq[
                     target + 1 - start_position : target + 24 - start_position
                 ]
-                if "TTTT" not in sgRNA:
+                if "TTTT" not in sgRNA[:20]:
                     ct_grna.append(sgRNA)
     return ct_grna
 
@@ -40,6 +40,6 @@ def convert_ga_grna(ds: GeneData, indices: list[int]) -> list[str]:
             add_num = match.start()
             if 0 <= int(add_num) <= 3:
                 sgRNA = ds.orf_seq[target - 20 + add_num : target + 3 + add_num]
-                if "TTTT" not in sgRNA:
+                if "AAAA" not in sgRNA[3:]:
                     ga_grna.append(sgRNA)
     return ga_grna

--- a/src/konezumiaid/nominate_candidate_stopcodon/transform_candidateseq_to_index.py
+++ b/src/konezumiaid/nominate_candidate_stopcodon/transform_candidateseq_to_index.py
@@ -24,7 +24,7 @@ def transform_ga_guideseq_to_index(orf_seq: str, targets: list[str]) -> list[int
         for match in re.finditer(target, orf_seq):
             rev_match = match.group()[::-1]
             # Get the index of the candidate gRNA end position in the ORF and back to "T" in "TGG"
-            if  rev_match[0:2]=="GGT" and rev_match[3:5]=="GGT":        
+            if  rev_match[0:3]=="GGT" and rev_match[3:6]=="GGT":        
                 positions.append(match.start() + len(match.group()) - 3 )
                 positions.append(match.start() + len(match.group()) - 3 - 3)
             else:

--- a/src/konezumiaid/nominate_candidate_stopcodon/transform_candidateseq_to_index.py
+++ b/src/konezumiaid/nominate_candidate_stopcodon/transform_candidateseq_to_index.py
@@ -9,7 +9,7 @@ def transform_ct_guideseq_to_index(orf_seq: str, targets: list[str]) -> list[int
         # Add the index of the candidate gRNA start position in the ORF and the index of "C" form gRNA start position
         for match in re.finditer(target, orf_seq):
             position = (
-                re.search(r"(CAA|CAG|CGA)", match.group()).start() + match.start()
+                re.search(r"(CAA|CAG|CGA)", match.group()[1:]).start() + match.start()+1
             )
             positions.append(position)
     positions = list(dict.fromkeys(positions))
@@ -23,8 +23,13 @@ def transform_ga_guideseq_to_index(orf_seq: str, targets: list[str]) -> list[int
     for target in targets:
         for match in re.finditer(target, orf_seq):
             rev_match = match.group()[::-1]
-            add_num = re.search("GGT", rev_match).start()
             # Get the index of the candidate gRNA end position in the ORF and back to "T" in "TGG"
-            positions.append(match.start() + len(match.group()) - 3 - add_num)
+            if  rev_match[1:3]=="GGT":
+                add_num = re.search("GGT", rev_match[1:]).start() + 1           
+                positions.append(match.start() + len(match.group()) - 3 - add_num-1)
+            else:
+                add_num = re.search("GGT", rev_match).start()               
+                positions.append(match.start() + len(match.group()) - 3 - add_num)
     positions = list(dict.fromkeys(positions))
     return positions
+

--- a/src/konezumiaid/nominate_candidate_stopcodon/transform_candidateseq_to_index.py
+++ b/src/konezumiaid/nominate_candidate_stopcodon/transform_candidateseq_to_index.py
@@ -24,9 +24,9 @@ def transform_ga_guideseq_to_index(orf_seq: str, targets: list[str]) -> list[int
         for match in re.finditer(target, orf_seq):
             rev_match = match.group()[::-1]
             # Get the index of the candidate gRNA end position in the ORF and back to "T" in "TGG"
-            if  rev_match[1:3]=="GGT":
-                add_num = re.search("GGT", rev_match[1:]).start() + 1           
-                positions.append(match.start() + len(match.group()) - 3 - add_num-1)
+            if  rev_match[0:2]=="GGT" and rev_match[3:5]=="GGT":        
+                positions.append(match.start() + len(match.group()) - 3 )
+                positions.append(match.start() + len(match.group()) - 3 - 3)
             else:
                 add_num = re.search("GGT", rev_match).start()               
                 positions.append(match.start() + len(match.group()) - 3 - add_num)

--- a/src/konezumiaid/nominate_spliceside_guide/search_candidate.py
+++ b/src/konezumiaid/nominate_spliceside_guide/search_candidate.py
@@ -4,31 +4,24 @@ from konezumiaid.create_gene_dataclass import GeneData
 
 def search_candidate(ds: GeneData) -> tuple[list[dict[int, str], list[dict[int, str]]]]:
     acceptor_cands = [
-        {
-            "seq": ds.orf_seq[s - 22 : s + 3][
-                ds.orf_seq[s - 22 : s + 3]
-                .index("CC") : ds.orf_seq[s - 22 : s + 3]
-                .index("CC")
-                + 23
-            ],
-            "exon_num": i + 2,
-        }
-        for i, s in enumerate(ds.exon_start_list[1:])
-        if "CC" in ds.orf_seq[s - 22 : s + 3][:4] and "AG" in ds.orf_seq[s - 2 : s]
-    ]
+    {
+        "seq": ds.orf_seq[s - 22 : s + 3][cc_idx : cc_idx + 23],
+        "exon_num": i + 2
+    }
+    for i,s in enumerate(ds.exon_start_list[1:])
+    if "CC" in ds.orf_seq[s - 22 : s + 3][:4] and "AG" in ds.orf_seq[s - 2 : s]
+    for cc_idx in [idx for idx in range(3) if ds.orf_seq[s - 22 : s + 3][idx : idx + 2] == "CC"]
+]
+
 
     donor_cands = [
         {
-            "seq": ds.orf_seq[e - 21 : e + 4][
-                ds.orf_seq[e - 21 : e + 4]
-                .index("CC") : ds.orf_seq[e - 21 : e + 4]
-                .index("CC")
-                + 23
-            ],
+            "seq": ds.orf_seq[e - 21 : e + 4][cc_idx : cc_idx + 23],
             "exon_num": i + 1,
         }
         for i, e in enumerate(ds.exon_end_list[:-1])
         if "CC" in ds.orf_seq[e - 21 : e + 4][:4] and "GT" in ds.orf_seq[e : e + 2]
+        for cc_idx in [idx for idx in range(3) if ds.orf_seq[e - 21 : e + 4][idx : idx + 2] == "CC"]
     ]
 
     acceptor_candidates = [

--- a/tests/src/test_nominate_candidate_stopcodon/test_make_grna_from_index.py
+++ b/tests/src/test_nominate_candidate_stopcodon/test_make_grna_from_index.py
@@ -61,7 +61,7 @@ def test_nocandidate_convert_ct_grna():
 
 def test_nocandidate_convert_ga_grna():
     ds = GeneData(
-        orf_seq="ATGCCPNNNNNNNNNNNNNNTGGNNNATCGAGCCPNNNNNNNNNNNNNNNNNTGGCATATCCPNNNNNNNNNNNNNNTTTTGGAA",
+        orf_seq="ATGCCPNNNNNNNNNNNNNNTGGNNNATCGAGCCPNNNNNNNNNNNNNNNNNTGGCATATCCPNNNNNNNNNNNNNNAAAAGGAA",
         txStart=0,
         txend=85,
         cdsStart=0,

--- a/tests/src/test_nominate_candidate_stopcodon/test_transform_candidateseq_to_index.py
+++ b/tests/src/test_nominate_candidate_stopcodon/test_transform_candidateseq_to_index.py
@@ -88,7 +88,7 @@ seq_candidates = [
     ["CCNCCCNNNNNNNNNNNNNNTGG", "CCCNNNNNNNNNNNNNNTGGTGG", "CCNNNNNNNNNNNNNNTGGTGGN"],
     ["CCNNNNNNNNNNNNNNNTGGTGG"]
 ]
-expected = [[17], [18], [19], [20], [20, 43], [20, 23],[17, 20]]
+expected = [[17], [18], [19], [20], [20, 43], [20, 23],[20, 17]]
 
 
 @pytest.mark.parametrize(

--- a/tests/src/test_nominate_candidate_stopcodon/test_transform_candidateseq_to_index.py
+++ b/tests/src/test_nominate_candidate_stopcodon/test_transform_candidateseq_to_index.py
@@ -88,7 +88,7 @@ seq_candidates = [
     ["CCNCCCNNNNNNNNNNNNNNTGG", "CCCNNNNNNNNNNNNNNTGGTGG", "CCNNNNNNNNNNNNNNTGGTGGN"],
     ["CCNNNNNNNNNNNNNNNTGGTGG"]
 ]
-expected = [[17], [18], [19], [20], [20, 43], [20, 23],[17, 23]]
+expected = [[17], [18], [19], [20], [20, 43], [20, 23],[17, 20]]
 
 
 @pytest.mark.parametrize(

--- a/tests/src/test_nominate_candidate_stopcodon/test_transform_candidateseq_to_index.py
+++ b/tests/src/test_nominate_candidate_stopcodon/test_transform_candidateseq_to_index.py
@@ -24,6 +24,7 @@ input_seq = [
     "NNNCGANNNNNNNNNNNNNNNGG",
     "NNCAGNNNNNNNNNNNNNNNNGGCGANNNNNNNNNNNNNNNNGG",  # multipme candidates
     "NNCAGCAANNNNNNNNNNNNNGGTGG",  # multipme candidates
+    "NNCAGCAANNNNNNNNNNNNNGGGGG" # multipme candidates and G rich around PAM 
 ]
 seq_candidates = [
     ["NCAANNNNNNNNNNNNNNNNNGG"],
@@ -37,9 +38,10 @@ seq_candidates = [
     ["NNNCGANNNNNNNNNNNNNNNGG"],
     ["NNCAGNNNNNNNNNNNNNNNNGG", "GGCGANNNNNNNNNNNNNNNNGG"],
     ["NNCAGCAANNNNNNNNNNNNNGG", "AGCAANNNNNNNNNNNNNGGTGG"],
+    ["NNCAGCAANNNNNNNNNNNNNGG", "CAGCAANNNNNNNNNNNNNGGGG"],
 ]
 
-expected = [[1], [1], [1], [2], [2], [2], [3], [3], [3], [2, 23], [2, 5]]
+expected = [[1], [1], [1], [2], [2], [2], [3], [3], [3], [2, 23], [2, 5],[2, 5]]
 
 
 @pytest.mark.parametrize(
@@ -76,7 +78,7 @@ input_seq = [
     "CCNNNNNNNNNNNNNNNNNNTGG",
     "CCNNNNNNNNNNNNNNNNNNTGGCCANNNNNNNNNNNNNNNNNTGG",  # multipme candidates
     "CCNCCCNNNNNNNNNNNNNNTGGTGGNNNN",  # multipme candidates
-]
+    "CCNNNNNNNNNNNNNNNTGGTGGNN" ]# multipme candidates in the same candidate
 seq_candidates = [
     ["CCNNNNNNNNNNNNNNNTGGNNN"],
     ["CCNNNNNNNNNNNNNNNNTGGNN"],
@@ -84,8 +86,9 @@ seq_candidates = [
     ["CCNNNNNNNNNNNNNNNNNNTGG"],
     ["CCNNNNNNNNNNNNNNNNNNTGG", "CCANNNNNNNNNNNNNNNNNTGG"],
     ["CCNCCCNNNNNNNNNNNNNNTGG", "CCCNNNNNNNNNNNNNNTGGTGG", "CCNNNNNNNNNNNNNNTGGTGGN"],
+    ["CCNNNNNNNNNNNNNNNTGGTGG"]
 ]
-expected = [[17], [18], [19], [20], [20, 43], [20, 23]]
+expected = [[17], [18], [19], [20], [20, 43], [20, 23],[20, 23]]
 
 
 @pytest.mark.parametrize(

--- a/tests/src/test_nominate_candidate_stopcodon/test_transform_candidateseq_to_index.py
+++ b/tests/src/test_nominate_candidate_stopcodon/test_transform_candidateseq_to_index.py
@@ -88,7 +88,7 @@ seq_candidates = [
     ["CCNCCCNNNNNNNNNNNNNNTGG", "CCCNNNNNNNNNNNNNNTGGTGG", "CCNNNNNNNNNNNNNNTGGTGGN"],
     ["CCNNNNNNNNNNNNNNNTGGTGG"]
 ]
-expected = [[17], [18], [19], [20], [20, 43], [20, 23],[20, 23]]
+expected = [[17], [18], [19], [20], [20, 43], [20, 23],[17, 23]]
 
 
 @pytest.mark.parametrize(

--- a/tests/src/testnominate_spliceside_guide/test_seaech_candidate.py
+++ b/tests/src/testnominate_spliceside_guide/test_seaech_candidate.py
@@ -4,7 +4,7 @@ from konezumiaid.create_gene_dataclass import GeneData
 
 def test_no_candidate():
     data = GeneData(
-        "NNNNGGCCNNNNNNNTTTTNNNNNNGTAGNCCNNNNNNNNNNNNNNNNNNGANNNNNNNCCNNNNNNNNNNNNNNNNAGNNNNNNNNNNNNNNNNNNNN",
+        "NNNNGGCCNNNNNNNTTTTNNNNNNGTAGNCCNNNNNNNNNNNNNNNNNNGANNNNNNNCCNNNNNNNNNNNNNNNNAGNNNNNNNNNNNNNNNNNNNNN",
         # PAM isn't CC,there is TTTT in the sequence, Donor isn't GT , Acceptor isn't AG, and .
         0,
         100,
@@ -22,7 +22,7 @@ def test_no_candidate():
 
 def test_has_candidate():
     data = GeneData(
-        "NNNNCCNNNNNNNNNNNNNNNNNNNGTNNNCCNNNNNNNNNNNNNNNNNNGTNNNNNNNCCNNNNNNNNNNNNNNNNNAGNNNNNNNNNNNNNNNNNNN",
+        "NNNNCCCNNNNNNNNNNNNNNNNNNGTNNNCCNNNNNNNNNNNNNNNNNNGTNNNNNNNCCNNNNNNNNNNNNNNNNNAGNNNNNNNNNNNNNNNNNNNN",
         0,
         100,
         0,
@@ -36,7 +36,8 @@ def test_has_candidate():
     excepted = (
         [{"seq": "CCNNNNNNNNNNNNNNNNNAGNN", "exon_num": 3}],
         [
-            {"seq": "CCNNNNNNNNNNNNNNNNNNNGT", "exon_num": 1},
+            {"seq": "CCCNNNNNNNNNNNNNNNNNNGT", "exon_num": 1},
+            {"seq": "CCNNNNNNNNNNNNNNNNNNGTN", "exon_num": 1},
             {"seq": "CCNNNNNNNNNNNNNNNNNNGTN", "exon_num": 2},
         ],
     )


### PR DESCRIPTION
以下の3点を変更しました。

1. 同一スプライスサイトを狙う複数ガイドが組める場合に1つしか表示されなかったバグを解消しました。
2. PTCを作成するガイドにおいて編集を受けるCのポジションの取得でバグがあった部分を修正しました。
3. TTTTを含むガイドの取り除き方を変更しました。

strand -の遺伝子について、初めに逆相補鎖をとったことによる問題については触れていません。
リファクタリングに移りたいと思うため、こちらのマージをお願いします。