### PR TITLE
データセットの作成部分の修正

### DIFF
--- a/src/konezumiaid/create_gene_dataclass.py
+++ b/src/konezumiaid/create_gene_dataclass.py
@@ -21,7 +21,8 @@ def create_dataclass(transcript_name: str, refflat: list[dict], transcript_seq_d
         None,
     )
     if transcript_filtered is None:
-        raise ValueError("Transcript name doesn't exist in the refflat")
+        print("The transcript doesn't exist in the refflat")
+        return None
 
     txStart = int(transcript_filtered["txStart"])
     txEnd = int(transcript_filtered["txEnd"])
@@ -33,7 +34,8 @@ def create_dataclass(transcript_name: str, refflat: list[dict], transcript_seq_d
 
     orf_seq = transcript_seq_dict.get(f"{transcript_name}")
     if orf_seq is None:
-        raise ValueError("Transcript sequence doesn't exist in the transcript_seq_dict")
+        print("the transcript sequence doesn't exist in formatted sequence dictionary")
+        return None
 
     transcript_record = GeneData(
         orf_seq,

--- a/src/konezumiaid/create_gene_dataclass.py
+++ b/src/konezumiaid/create_gene_dataclass.py
@@ -14,22 +14,15 @@ class GeneData:
     exon_end_list: list[int]
 
 
-def create_dataclass(
-    transcript_name: str, refflat: list[dict], transcript_seq_dict: dict
-) -> GeneData:
+def create_dataclass(transcript_name: str, refflat: list[dict], transcript_seq_dict: dict) -> GeneData:
     # Create dataclass from the transcript name.
     transcript_filtered = next(
-        (
-            transcript_data
-            for transcript_data in refflat
-            if transcript_data["name"] == transcript_name
-        ),
+        (transcript_data for transcript_data in refflat if transcript_data["name"] == transcript_name),
         None,
     )
     if transcript_filtered is None:
         raise ValueError("Transcript name doesn't exist in the refflat")
 
-    chrom = str(transcript_filtered["chrom"])
     txStart = int(transcript_filtered["txStart"])
     txEnd = int(transcript_filtered["txEnd"])
     cdsStart = int(transcript_filtered["cdsStart"])
@@ -38,8 +31,7 @@ def create_dataclass(
     exon_start_list = [int(x) for x in transcript_filtered["exonStarts"].split(",")]
     exon_end_list = [int(x) for x in transcript_filtered["exonEnds"].split(",")]
 
-    key = f"{transcript_name}::{chrom}:{txStart}-{txEnd}"
-    orf_seq = transcript_seq_dict.get(key)
+    orf_seq = transcript_seq_dict.get(f"{transcript_name}")
     if orf_seq is None:
         raise ValueError("Transcript sequence doesn't exist in the transcript_seq_dict")
 

--- a/src/konezumiaid/create_gene_dataclass.py
+++ b/src/konezumiaid/create_gene_dataclass.py
@@ -21,8 +21,7 @@ def create_dataclass(transcript_name: str, refflat: list[dict], transcript_seq_d
         None,
     )
     if transcript_filtered is None:
-        print("The transcript doesn't exist in the refflat")
-        return None
+        raise ValueError("The transcript doesn't exist in the refflat")
 
     txStart = int(transcript_filtered["txStart"])
     txEnd = int(transcript_filtered["txEnd"])
@@ -34,8 +33,7 @@ def create_dataclass(transcript_name: str, refflat: list[dict], transcript_seq_d
 
     orf_seq = transcript_seq_dict.get(f"{transcript_name}")
     if orf_seq is None:
-        print("the transcript sequence doesn't exist in formatted sequence dictionary")
-        return None
+        raise ValueError("The transcript sequence doesn't exist in formatted sequence dictionary")
 
     transcript_record = GeneData(
         orf_seq,

--- a/src/konezumiaid/format_and_export_dataset/convert_refflat_to_bed6.py
+++ b/src/konezumiaid/format_and_export_dataset/convert_refflat_to_bed6.py
@@ -2,7 +2,8 @@ from __future__ import annotations
 import pandas as pd
 from pathlib import Path
 
-def convert_refFlat_to_bed6(df_refflat: pd.DataFrame , output_file: Path) -> None
+
+def convert_refFlat_to_bed6(df_refflat: pd.DataFrame, output_file: Path) -> None:
     with open(output_file, "w") as outfile:
         for _, row in df_refflat.iterrows():
             chrom = row["chrom"]
@@ -12,8 +13,5 @@ def convert_refFlat_to_bed6(df_refflat: pd.DataFrame , output_file: Path) -> Non
             score = "0"
             strand = row["strand"]
 
-            bed_line = "\t".join(
-                [chrom, txStart, txEnd, transcriot_name, score, strand]
-            )
+            bed_line = "\t".join([chrom, txStart, txEnd, transcriot_name, score, strand])
             outfile.write(bed_line + "\n")
-                        

--- a/src/konezumiaid/format_and_export_dataset/convert_refflat_to_bed6.py
+++ b/src/konezumiaid/format_and_export_dataset/convert_refflat_to_bed6.py
@@ -1,20 +1,19 @@
 from __future__ import annotations
+import pandas as pd
 from pathlib import Path
 
-
-def convert_refFlat_to_bed6(refFlat_file: Path, output_file: Path) -> None:
-    with open(refFlat_file, "r") as infile, open(output_file, "w") as outfile:
-        for line in infile:
-            fields = line.strip().split("\t")
-
-            chrom = fields[2]
-            txStart = fields[4]
-            txEnd = fields[5]
-            transcriot_name = fields[1]
+def convert_refFlat_to_bed6(df_refflat: pd.DataFrame , output_file: Path) -> None
+    with open(output_file, "w") as outfile:
+        for _, row in df_refflat.iterrows():
+            chrom = row["chrom"]
+            txStart = row["txStart"]
+            txEnd = row["txEnd"]
+            transcriot_name = row["name"]
             score = "0"
-            strand = fields[3]
+            strand = row["strand"]
 
             bed_line = "\t".join(
                 [chrom, txStart, txEnd, transcriot_name, score, strand]
             )
             outfile.write(bed_line + "\n")
+                        

--- a/src/konezumiaid/format_and_export_dataset/generate_seq_dict_from_fasta.py
+++ b/src/konezumiaid/format_and_export_dataset/generate_seq_dict_from_fasta.py
@@ -21,40 +21,21 @@ def read_fasta(path_fasta: str) -> dict[str, str]:
     return fasta
 
 
-def create_dict_keys(df_refflat: pd.DataFrame) -> dict[str, str]:
-    """Create a unique key for each transcript for the sequence dictionary."""
-    transcript_names = df_refflat["name"].tolist()
-    keys = []
-    for transcript_name in transcript_names:
-        df_transcript = df_refflat[df_refflat["name"] == transcript_name]
-        chrom = str(df_transcript["chrom"].iloc[0])
-        txStart = str(df_transcript["txStart"].iloc[0])
-        txEnd = str(df_transcript["txEnd"].iloc[0])
-        query = f"{transcript_name}::{chrom}:{txStart}-{txEnd}"
-        keys.append(query)
-    return keys
-
-
 def create_strand_plus_seq_dict(
     df_refflat: pd.DataFrame,
-    df_refflat_sorted: pd.DataFrame,
     transcript_seq_dict: dict[str, str],
 ) -> dict[str, str]:
     """convert the sequence dictionary from fasta to the sequence dictionary.
     Reverse the sequence and change key if the transcript is negative strand."""
-    transcripts_fasta_keys = create_dict_keys(df_refflat)
-    sorted_keys = create_dict_keys(df_refflat_sorted)
-    name_list = df_refflat["name"].tolist()
+    fasta_keys = df_refflat["name"].tolist()
     result_dict = {}
 
-    for transcript_name, fasta_key, sorted_key in zip(
-        name_list, transcripts_fasta_keys, sorted_keys
-    ):
-        strand = df_refflat.loc[df_refflat["name"] == transcript_name, "strand"].iloc[0]
+    for fasta_key in fasta_keys:
+        strand = df_refflat.loc[df_refflat["name"] == fasta_key, "strand"].iloc[0]
         if strand == "-":
             converted_seq = get_revcomp(transcript_seq_dict[fasta_key])
         else:
             converted_seq = transcript_seq_dict[fasta_key]
 
-        result_dict[sorted_key] = converted_seq.upper()
+        result_dict[fasta_key] = converted_seq.upper()
     return result_dict

--- a/src/konezumiaid/format_and_export_dataset/main.py
+++ b/src/konezumiaid/format_and_export_dataset/main.py
@@ -76,7 +76,7 @@ def execute_export(refflat_path: Path, fasta_path: Path):
         raise FileNotFoundError("One or both of the specified files were not found.")
     if refflat_path.suffix != ".txt":
         raise ValueError("The refflat file must be .txt file.")
-    if fasta_path.suffix != ".fa":
+    if fasta_path.suffix != ".fa" or fasta_path.suffix != ".fasta":
         raise ValueError("The fasta file must be .fa file.")
     export_pkl(refflat_path, fasta_path)
     print("Exported the dataset as pickle files.")

--- a/src/konezumiaid/format_and_export_dataset/main.py
+++ b/src/konezumiaid/format_and_export_dataset/main.py
@@ -2,8 +2,6 @@ from __future__ import annotations
 from pathlib import Path
 import pickle
 import subprocess
-import sys
-import argparse
 from konezumiaid.format_and_export_dataset.convert_refflat_to_bed6 import (
     convert_refFlat_to_bed6,
 )
@@ -17,14 +15,6 @@ from konezumiaid.format_and_export_dataset.generate_sorted_genedata_from_refflat
     remove_transcript_duplicates,
     remove_NR_transcripts,
 )
-
-
-parser = argparse.ArgumentParser(description="Format and export the dataset as pickle files.")
-
-parser.add_argument("refflat_path", type=Path, help="Path to the refFlat txt file.")
-parser.add_argument("chromosome_fasta_path", type=Path, help="Path to the chromosome fasta file.(ex. mm39.fa)")
-
-args = parser.parse_args()
 
 
 def export_pkl(refflat_path: Path, chromosome_fasta_path: Path) -> None:
@@ -81,9 +71,7 @@ def export_pkl(refflat_path: Path, chromosome_fasta_path: Path) -> None:
         pickle.dump(sorted_refflat, f)
 
 
-def export():
-    refflat_path = args.refflat_path
-    fasta_path = args.chromosome_fasta_path
+def excute_export(refflat_path: Path, fasta_path: Path):
     if not refflat_path.exists() or not fasta_path.exists():
         raise FileNotFoundError("One or both of the specified files were not found.")
     if refflat_path.suffix != ".txt":

--- a/src/konezumiaid/format_and_export_dataset/main.py
+++ b/src/konezumiaid/format_and_export_dataset/main.py
@@ -1,5 +1,4 @@
 from __future__ import annotations
-import sys
 from pathlib import Path
 import pickle
 import subprocess
@@ -74,13 +73,10 @@ def export_pkl(refflat_path: Path, chromosome_fasta_path: Path) -> None:
 
 def execute_export(refflat_path: Path, fasta_path: Path):
     if not refflat_path.exists() or not fasta_path.exists():
-        print("One or both of the specified files were not found.")
-        sys.exit(1)
+        raise FileNotFoundError("One or both of the specified files were not found.")
     if refflat_path.suffix != ".txt":
-        print("The refflat file must be .txt file.")
-        sys.exit(1)
+        raise ValueError("The refflat file must be .txt file.")
     if fasta_path.suffix != ".fa" or fasta_path.suffix != ".fasta":
-        print("The fasta file must be .fa or .fasta file.")
-        sys.exit(1)
+        raise ValueError("The fasta file must be .fa file.")
     export_pkl(refflat_path, fasta_path)
     print("Exported the dataset as pickle files.")

--- a/src/konezumiaid/format_and_export_dataset/main.py
+++ b/src/konezumiaid/format_and_export_dataset/main.py
@@ -77,6 +77,6 @@ def execute_export(refflat_path: Path, fasta_path: Path):
     if refflat_path.suffix != ".txt":
         raise ValueError("The refflat file must be .txt file.")
     if fasta_path.suffix != ".fa" or fasta_path.suffix != ".fasta":
-        raise ValueError("The fasta file must be .fa file.")
+        raise ValueError("The fasta file must be .fa or .fasta file.")
     export_pkl(refflat_path, fasta_path)
     print("Exported the dataset as pickle files.")

--- a/src/konezumiaid/format_and_export_dataset/main.py
+++ b/src/konezumiaid/format_and_export_dataset/main.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+import sys
 from pathlib import Path
 import pickle
 import subprocess
@@ -73,10 +74,13 @@ def export_pkl(refflat_path: Path, chromosome_fasta_path: Path) -> None:
 
 def execute_export(refflat_path: Path, fasta_path: Path):
     if not refflat_path.exists() or not fasta_path.exists():
-        raise FileNotFoundError("One or both of the specified files were not found.")
+        print("One or both of the specified files were not found.")
+        sys.exit(1)
     if refflat_path.suffix != ".txt":
-        raise ValueError("The refflat file must be .txt file.")
+        print("The refflat file must be .txt file.")
+        sys.exit(1)
     if fasta_path.suffix != ".fa" or fasta_path.suffix != ".fasta":
-        raise ValueError("The fasta file must be .fa file.")
+        print("The fasta file must be .fa or .fasta file.")
+        sys.exit(1)
     export_pkl(refflat_path, fasta_path)
     print("Exported the dataset as pickle files.")

--- a/src/konezumiaid/format_and_export_dataset/main.py
+++ b/src/konezumiaid/format_and_export_dataset/main.py
@@ -71,7 +71,7 @@ def export_pkl(refflat_path: Path, chromosome_fasta_path: Path) -> None:
         pickle.dump(sorted_refflat, f)
 
 
-def excute_export(refflat_path: Path, fasta_path: Path):
+def execute_export(refflat_path: Path, fasta_path: Path):
     if not refflat_path.exists() or not fasta_path.exists():
         raise FileNotFoundError("One or both of the specified files were not found.")
     if refflat_path.suffix != ".txt":

--- a/src/konezumiaid/format_and_export_dataset/translate_bed_from_refflat.sh
+++ b/src/konezumiaid/format_and_export_dataset/translate_bed_from_refflat.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 # Execute bedtools getfasta command
-bedtools getfasta -name+ -fi $1 -bed $2 -fo $3
+bedtools getfasta -nameOnly -fi $1 -bed $2 -fo $3

--- a/tests/src/test_create_gene_dataclass.py
+++ b/tests/src/test_create_gene_dataclass.py
@@ -24,7 +24,7 @@ input_genedata = [
 input_transcript_name = ["t1"]  # test_df["name"]
 
 input_seq = [
-    {"t1::chr1:0-30": "NNNNNNNNNNATGTNNNNNNNNNNNNNNNN"}
+    {"t1": "NNNNNNNNNNATGTNNNNNNNNNNNNNNNN"}
 ]  # dict key is "{transcripts_name}::{chrom}:{txStart}-{txEnd}". Value is orf_seq.
 
 
@@ -59,6 +59,4 @@ expected = [expected_return]
     zip(input_transcript_name, [input_genedata], input_seq, expected),
 )
 def test_setup_data(transcripts_name, gene_data, gene_seq_data, expected):
-    assert asdict(
-        create_dataclass(transcripts_name, gene_data, gene_seq_data)
-    ) == asdict(expected)
+    assert asdict(create_dataclass(transcripts_name, gene_data, gene_seq_data)) == asdict(expected)

--- a/tests/src/test_format_and_export_dataset/test_seq_dict.py
+++ b/tests/src/test_format_and_export_dataset/test_seq_dict.py
@@ -21,7 +21,7 @@ def test_read_fasta():
     assert read_fasta(temp_file_name) == expected
 
 
-def test_create_sorted_seq_dict():
+def test_create_strand_plus_seq_dict():
     gene_data = [
         {
             "geneName": "Xkr4",
@@ -50,34 +50,6 @@ def test_create_sorted_seq_dict():
             "exonEnds": "15,25,35,45",
         },
     ]
-    sort_gene_data = [
-        {
-            "geneName": "Xkr4",
-            "name": "NM_001011874",
-            "chrom": "chr1",
-            "strand": "-",
-            "txStart": 0,
-            "txEnd": 100,
-            "cdsStart": 0,
-            "cdsEnd": 100,
-            "exonCount": "3",
-            "exonStarts": "0,20,40",
-            "exonEnds": "10,30,50",
-        },
-        {
-            "geneName": "Lypla1",
-            "name": "NM_001355712",
-            "chrom": "chr1",
-            "strand": "+",
-            "txStart": 0,
-            "txEnd": 100,
-            "cdsStart": 0,
-            "cdsEnd": 100,
-            "exonCount": "4",
-            "exonStarts": "0,10,20,30",
-            "exonEnds": "5,15,25,35",
-        },
-    ]
     seq_dict = {
         "NM_001011874": "ATGC",
         "NM_001355712": "TTGGCC",
@@ -86,4 +58,4 @@ def test_create_sorted_seq_dict():
         "NM_001011874": "GCAT",
         "NM_001355712": "TTGGCC",
     }
-    assert create_strand_plus_seq_dict(pd.DataFrame(gene_data), pd.DataFrame(sort_gene_data), seq_dict) == expected
+    assert create_strand_plus_seq_dict(pd.DataFrame(gene_data), seq_dict) == expected

--- a/tests/src/test_format_and_export_dataset/test_seq_dict.py
+++ b/tests/src/test_format_and_export_dataset/test_seq_dict.py
@@ -1,14 +1,9 @@
 from src.konezumiaid.format_and_export_dataset.generate_seq_dict_from_fasta import (
     read_fasta,
-    create_dict_keys,
     create_strand_plus_seq_dict,
 )
-from src.konezumiaid.format_and_export_dataset.generate_sorted_genedata_from_refflat import (
-    built_gene_dataframe,
-    clean_refflat,
-)
+
 from tempfile import NamedTemporaryFile
-from pathlib import Path
 import pandas as pd
 
 
@@ -24,16 +19,6 @@ def test_read_fasta():
 
     # Test the function
     assert read_fasta(temp_file_name) == expected
-
-
-def test_create_dict_keys():
-    path_refFlat = Path("tests/data/example_refFlat.txt")
-    genedata = built_gene_dataframe(path_refFlat)
-    expected = [
-        "NM_001011874::chr1:3284704-3741721",
-        "NM_001370921::chr1:4190088-4430526",
-    ]
-    assert create_dict_keys(genedata) == expected
 
 
 def test_create_sorted_seq_dict():
@@ -94,16 +79,11 @@ def test_create_sorted_seq_dict():
         },
     ]
     seq_dict = {
-        "NM_001011874::chr1:10-110": "ATGC",
-        "NM_001355712::chr1:10-110": "TTGGCC",
+        "NM_001011874": "ATGC",
+        "NM_001355712": "TTGGCC",
     }
     expected = {
-        "NM_001011874::chr1:0-100": "GCAT",
-        "NM_001355712::chr1:0-100": "TTGGCC",
+        "NM_001011874": "GCAT",
+        "NM_001355712": "TTGGCC",
     }
-    assert (
-        create_strand_plus_seq_dict(
-            pd.DataFrame(gene_data), pd.DataFrame(sort_gene_data), seq_dict
-        )
-        == expected
-    )
+    assert create_strand_plus_seq_dict(pd.DataFrame(gene_data), pd.DataFrame(sort_gene_data), seq_dict) == expected

--- a/tests/src/test_format_and_export_dataset/test_sorted_genedata.py
+++ b/tests/src/test_format_and_export_dataset/test_sorted_genedata.py
@@ -76,7 +76,7 @@ def test_built_gene_dataframe():
     assert test_dataframe.to_dict(orient="records") == expected
 
 
-def test_sort_gene_dataframe():
+def test_clean_refflat():
     test = [
         {
             "geneName": "Xkr4",
@@ -164,7 +164,7 @@ def test_sort_gene_dataframe():
     assert result_dataframe.to_dict(orient="records") == excepted
 
 
-def test_remove_genedata_duplicates():
+def test_remove_transcript_duplicates():
     test = [
         {
             "geneName": "Xkr4",

--- a/tests/src/test_nominate_ptc_guide/test_generate_cds_seq.py
+++ b/tests/src/test_nominate_ptc_guide/test_generate_cds_seq.py
@@ -40,8 +40,8 @@ input_genedata = [
     },
 ]
 orf_seq_dict = {
-    "t1::chr1:0-100": "1NNNNNNNNNATGNNNNNNNNNNNN2CAGNNNNNNNNNNNNNNNNNGGNNNNNNNNNNNN3NNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNENNNNN",
-    "t2::chr1:0-30": "NNNNNNNNNNATGTNANNNNNNNNNNNNNN",
+    "t1": "1NNNNNNNNNATGNNNNNNNNNNNN2CAGNNNNNNNNNNNNNNNNNGGNNNNNNNNNNNN3NNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNENNNNN",
+    "t2": "NNNNNNNNNNATGTNANNNNNNNNNNNNNN",
 }
 
 test_name = ["t1", "t2"]
@@ -62,10 +62,7 @@ expected_return = [
     ),
 )
 def test_get_exon_seq(test_name, input_genedata, orf_seq_dict, expected):
-    assert (
-        generate_exon_seq(create_dataclass(test_name, input_genedata, orf_seq_dict))
-        == expected
-    )
+    assert generate_exon_seq(create_dataclass(test_name, input_genedata, orf_seq_dict)) == expected
 
 
 #####
@@ -82,12 +79,7 @@ expected_return = [0, 1]
     ),
 )
 def test_get_startcodon_exon_num(test_name, input_genedata, orf_seq_dict, expected):
-    assert (
-        get_startcodon_exon_index(
-            create_dataclass(test_name, input_genedata, orf_seq_dict)
-        )
-        == expected
-    )
+    assert get_startcodon_exon_index(create_dataclass(test_name, input_genedata, orf_seq_dict)) == expected
 
 
 #####
@@ -104,12 +96,7 @@ expected_return = [2, 2]
     ),
 )
 def test_get_stopcodon_exon_num(test_name, input_genedata, orf_seq_dict, expected):
-    assert (
-        get_stopcodon_exon_index(
-            create_dataclass(test_name, input_genedata, orf_seq_dict)
-        )
-        == expected
-    )
+    assert get_stopcodon_exon_index(create_dataclass(test_name, input_genedata, orf_seq_dict)) == expected
 
 
 #####

--- a/tests/src/test_nominate_ptc_guide/test_translate_idex_in_exon_to_orf.py
+++ b/tests/src/test_nominate_ptc_guide/test_translate_idex_in_exon_to_orf.py
@@ -37,8 +37,8 @@ input_genedata = [
     },
 ]
 orf_seq_dict = {
-    "t1::chr1:0-100": "1NNNNNNNNNATGNNNNNNNNNNNN2CAGNNNNNNNNNNNNNNNNNGGNNNNNNNNNNNN3NNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNENNNNN",
-    "t2::chr1:0-30": "NNNNNNNNNNATGTNANNNNNNNNNNNNNN",
+    "t1": "1NNNNNNNNNATGNNNNNNNNNNNN2CAGNNNNNNNNNNNNNNNNNGGNNNNNNNNNNNN3NNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNENNNNN",
+    "t2": "NNNNNNNNNNATGTNANNNNNNNNNNNNNN",
 }
 test_name = ["t1", "t2"]
 expected = [[0, 14], [15, 39], [40, 74]], [[0, 2], [3, 10], [11, 24]]
@@ -54,10 +54,7 @@ expected = [[0, 14], [15, 39], [40, 74]], [[0, 2], [3, 10], [11, 24]]
     ),
 )
 def test_get_range_of_exon(test_name, input_genedata, orf_seq_dict, expected):
-    assert (
-        get_exon_range(create_dataclass(test_name, input_genedata, orf_seq_dict))
-        == expected
-    )
+    assert get_exon_range(create_dataclass(test_name, input_genedata, orf_seq_dict)) == expected
 
 
 # there is the candidate stopcodon
@@ -201,9 +198,7 @@ expected = [[]]
         expected,
     ),
 )
-def test_nocandidate_get_candidate_stopcodon_exon_num(
-    candidate_stopcodon, exon_range, expected
-):
+def test_nocandidate_get_candidate_stopcodon_exon_num(candidate_stopcodon, exon_range, expected):
     assert get_exonindex_in_cand_codon(candidate_stopcodon, exon_range) == expected
 
 


### PR DESCRIPTION
データセットの作成部分を修正しました．

1. transcrioptの重複やNM_の転写産物の削除を一番初めにおこなうようにしました．
2. それに伴いbedtoolsの出力fastaのヘッダーの一意性が確保されるのでtranscriopt名をヘッダーに変更しました．また削除をpd.DataFrameで行ったため，bed6の作成で引数の型を変更しました．
3. これに伴い，seq_dictのkey名も簡略化されました．参照位置が多いため多数の部分でkey名の変更が反映されています．

exportの部分について[PR92](https://github.com/aki2274/KOnezumi-AID/pull/92)でサブコマンド化するためにexecute_export()を新たに追加しました．また，argparseについてはコミットされてますが，削除しました．